### PR TITLE
Hotfix UrdfAssetPathHandler for structure change

### DIFF
--- a/com.unity.robotics.urdf-importer/Runtime/AssetHandlers/UrdfAssetPathHandler.cs
+++ b/com.unity.robotics.urdf-importer/Runtime/AssetHandlers/UrdfAssetPathHandler.cs
@@ -55,7 +55,7 @@ namespace Unity.Robotics.UrdfImporter
                 if (dirPath.Contains("/src/"))
                 {
                     var wsPath = dirPath[..dirPath.IndexOf("src/")];
-                    if(File.Exists(wsPath + ".catkin_workspace"))
+                    if(File.Exists(wsPath + ".catkin_workspace")  || Directory.Exists(wsPath + ".catkin_tools") || Directory.Exists(wsPath + "devel"))
                         return paths.Append(wsPath+"src/");
                 }
                 return paths;


### PR DESCRIPTION
## Proposed change(s)

the new infrastructure doesn't generate a .catkin_workspace, so the check if it is a catkin workspace fails.
This is a simple hotfix with additional checks for if it is a catkin workspace